### PR TITLE
podman: resolved remaining podman 5.3 issues

### DIFF
--- a/modules/services/podman-linux/services.nix
+++ b/modules/services/podman-linux/services.nix
@@ -61,5 +61,12 @@ in {
         Install = { WantedBy = [ "timers.target" ]; };
       };
     })
+    ({
+      xdg.configFile."systemd/user/podman-user-wait-network-online.service.d/50-exec-search-path.conf".text =
+        ''
+          [Service]
+          ExecSearchPath=${pkgs.bashInteractive}/bin:${pkgs.systemd}/bin:/bin
+        '';
+    })
   ]);
 }

--- a/tests/modules/services/podman-linux/network-expected.service
+++ b/tests/modules/services/podman-linux/network-expected.service
@@ -23,11 +23,14 @@ Environment=PATH=/run/wrappers/bin:/usr/bin:/bin:/usr/sbin:/sbin:/nix/store/0000
 ExecStartPre=/nix/store/00000000000000000000000000000000-await-podman-unshare
 RemainAfterExit=yes
 TimeoutStartSec=15
-ExecStart=/nix/store/00000000000000000000000000000000-podman/bin/podman network create --ignore --subnet=192.168.1.0/24 --gateway=192.168.1.1 --opt isolate=true --label nix.home-manager.managed=true --ipam-driver dhcp --dns=192.168.55.1 --log-level=debug my-net
-Type=oneshot
+ExecStart=/nix/store/00000000000000000000000000000000-podman/bin/podman network create --ignore --subnet 192.168.1.0/24 --gateway 192.168.1.1 --opt isolate=true --label nix.home-manager.managed=true --ipam-driver dhcp --dns=192.168.55.1 --log-level=debug my-net
 SyslogIdentifier=%N
+Type=oneshot
 
 [Unit]
+Wants=podman-user-wait-network-online.service
+After=podman-user-wait-network-online.service
 After=network.target
 Description=Service for network my-net
+SourcePath=/nix/store/00000000000000000000000000000000-home-network-podman-my-net/quadlets/podman-my-net.network
 RequiresMountsFor=%t/containers


### PR DESCRIPTION
### Description

@GaetanLepage has resolved most of the failing tests as a result of the upgrade to podman 5.3.0, but the network test was still failing. This PR resolves that.

This PR also resolves an issue with Podman 5.3.0's new `podman-user-wait-network-online.service` quadlet dependency being unable to resolve `sh` and `systemctl`, and failing as a result.

### Checklist

- [x] Change is backwards compatible.

- [x] Code formatted with `./format`.

- [x] Code tested through `nix-shell --pure tests -A run.all`.

- [x] Test cases updated/added. See [example](https://github.com/nix-community/home-manager/commit/f3fbb50b68df20da47f9b0def5607857fcc0d021#diff-b61a6d542f9036550ba9c401c80f00ef).

- [x] Commit messages are formatted like

    ```
    {component}: {description}

    {long description}
    ```

    See [CONTRIBUTING](https://github.com/nix-community/home-manager/blob/master/docs/contributing.adoc#sec-commit-style) for more information and [recent commit messages](https://github.com/nix-community/home-manager/commits/master) for examples.

- If this PR adds a new module

  - [ ] Added myself as module maintainer. See [example](https://github.com/nix-community/home-manager/blob/068ff76a10e95820f886ac46957edcff4e44621d/modules/programs/lesspipe.nix#L6).

  - [ ] Added myself and the module files to `.github/CODEOWNERS`.
